### PR TITLE
Change blague 384 category to 'limit'

### DIFF
--- a/blagues.json
+++ b/blagues.json
@@ -2305,7 +2305,7 @@
   },
   {
     "id": 384,
-    "type": "global",
+    "type": "limit",
     "joke": "Qu’est ce qui sépare l’espèce humaine du singe ?",
     "answer": "La mer Méditerranée."
   },


### PR DESCRIPTION
Cette blague pourrait même être retirée en fait.
Elle est très offensante et pas drôle. A minima à ranger dans la catégorie "limit".