### PR TITLE
Ajout du status corrections obsolètes

### DIFF
--- a/prisma/migrations/20211209014235_stale_corrections/migration.sql
+++ b/prisma/migrations/20211209014235_stale_corrections/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "proposals" ADD COLUMN     "stale" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,28 +22,29 @@ model User {
 }
 
 model Godfather {
-  id        Int    @id @default(autoincrement())
-  user_id   String @unique @db.VarChar(255)
-  emoji_id  String @db.VarChar(255)
+  id       Int    @id @default(autoincrement())
+  user_id  String @unique @db.VarChar(255)
+  emoji_id String @db.VarChar(255)
 
   @@index([user_id], name: "godfathers_user_id")
   @@map("godfathers")
 }
 
 model Proposal {
-  id            Int          @id @default(autoincrement())
-  user_id       String?      @db.VarChar(255)
-  message_id    String?      @unique @db.VarChar(255)
+  id            Int           @id @default(autoincrement())
+  user_id       String?       @db.VarChar(255)
+  message_id    String?       @unique @db.VarChar(255)
   type          ProposalType
-  joke_id       Int?         @unique
-  joke_type     String?      @db.VarChar(255)
-  joke_question String?      @db.VarChar(255)
-  joke_answer   String?      @db.VarChar(255)
-  merged        Boolean      @default(false)
-  refused       Boolean      @default(false)
-  created_at    DateTime     @default(now())
+  joke_id       Int?          @unique
+  joke_type     String?       @db.VarChar(255)
+  joke_question String?       @db.VarChar(255)
+  joke_answer   String?       @db.VarChar(255)
+  merged        Boolean       @default(false)
+  refused       Boolean       @default(false)
+  stale         Boolean       @default(false)
+  created_at    DateTime      @default(now())
   approvals     Approval[]
-  disapprovals   Disapproval[]
+  disapprovals  Disapproval[]
 
   suggestion_id Int?
   suggestion    Proposal?  @relation("ProposalToCorrections", fields: [suggestion_id], references: [id], onDelete: Cascade)

--- a/src/bot/commands/approve.ts
+++ b/src/bot/commands/approve.ts
@@ -76,7 +76,8 @@ export default class ApproveCommand extends Command {
           },
           where: {
             merged: false,
-            refused: false
+            refused: false,
+            stale: false
           }
         },
         suggestion: {
@@ -87,7 +88,8 @@ export default class ApproveCommand extends Command {
               },
               where: {
                 merged: false,
-                refused: false
+                refused: false,
+                stale: false
               }
             },
             approvals: true,

--- a/src/bot/commands/disapprove.ts
+++ b/src/bot/commands/disapprove.ts
@@ -117,7 +117,7 @@ export default class DisapproveCommand extends Command {
             interaction.guild!.id
           }/${correctionsChannel}/${
           lastCorrection.message_id
-        }) par dessus rendant celle ci obselette, veuillez désapprouver la dernière version de la correction.`)
+        }) par dessus rendant celle ci obsolète, veuillez désapprouver la dernière version de la correction.`)
       );
     }
 

--- a/src/bot/commands/disapprove.ts
+++ b/src/bot/commands/disapprove.ts
@@ -48,7 +48,8 @@ export default class DisapproveCommand extends Command {
           },
           where: {
             merged: false,
-            refused: false
+            refused: false,
+            stale: false
           }
         },
         suggestion: {
@@ -60,7 +61,8 @@ export default class DisapproveCommand extends Command {
               },
               where: {
                 merged: false,
-                refused: false
+                refused: false,
+                stale: false
               }
             }
           }


### PR DESCRIPTION
Afin de ne pas pouvoir approuver/désapprouver la migration des corrections après qu'une correction basée sur cette dernière ait été approuvée.