### PR TITLE
Permissions par default des commandes (Approuver/Desaprouver )

### DIFF
--- a/src/bot/commands/approve.ts
+++ b/src/bot/commands/approve.ts
@@ -19,7 +19,8 @@ import {
   jokerRoleId,
   correctorRoleId,
   upReaction,
-  downReaction
+  downReaction,
+  godfatherRoleId
 } from '../constants';
 import Command from '../lib/command';
 import { renderGodfatherLine } from '../modules/godfathers';
@@ -68,7 +69,7 @@ export default class ApproveCommand extends Command {
     if (!isParrain(interaction.member)) {
       return interaction.reply(
         interactionProblem(
-          `Vous n'êtes pas parrain, vous ne pouvez pas approuver une ${isSuggestion ? 'blague' : 'correction'}.`
+          `Seuls un <@${godfatherRoleId}> peut approuver une ${isSuggestion ? 'blague' : 'correction'}.`
         )
       );
     }

--- a/src/bot/commands/approve.ts
+++ b/src/bot/commands/approve.ts
@@ -23,7 +23,14 @@ import {
 } from '../constants';
 import Command from '../lib/command';
 import { renderGodfatherLine } from '../modules/godfathers';
-import { interactionProblem, interactionInfo, interactionValidate, isEmbedable, messageLink } from '../utils';
+import {
+  interactionProblem,
+  interactionInfo,
+  interactionValidate,
+  isEmbedable,
+  messageLink,
+  isParrain
+} from '../utils';
 import Jokes from '../../jokes';
 import { compareTwoStrings } from 'string-similarity';
 
@@ -54,6 +61,14 @@ export default class ApproveCommand extends Command {
           `Vous ne pouvez pas approuver une ${isSuggestion ? 'blague' : 'correction'} qui n'est pas gérée par ${
             interaction.client.user
           }.`
+        )
+      );
+    }
+
+    if (!isParrain(interaction.member)) {
+      return interaction.reply(
+        interactionProblem(
+          `Vous n'êtes pas parrain, vous ne pouvez pas approuver une ${isSuggestion ? 'blague' : 'correction'}.`
         )
       );
     }

--- a/src/bot/commands/approve.ts
+++ b/src/bot/commands/approve.ts
@@ -69,7 +69,7 @@ export default class ApproveCommand extends Command {
     if (!isParrain(interaction.member)) {
       return interaction.reply(
         interactionProblem(
-          `Seuls un <@${godfatherRoleId}> peut approuver une ${isSuggestion ? 'blague' : 'correction'}.`
+          `Seul un <@${godfatherRoleId}> peut approuver une ${isSuggestion ? 'blague' : 'correction'}.`
         )
       );
     }

--- a/src/bot/commands/disapprove.ts
+++ b/src/bot/commands/disapprove.ts
@@ -10,6 +10,7 @@ import prisma from '../../prisma';
 import {
   Colors,
   correctionsChannelId,
+  godfatherRoleId,
   logsChannelId,
   neededCorrectionsApprovals,
   neededSuggestionsApprovals,
@@ -58,7 +59,7 @@ export default class DisapproveCommand extends Command {
     if (!isParrain(interaction.member)) {
       return interaction.reply(
         interactionProblem(
-          `Vous n'êtes pas parrain, vous ne pouvez pas désapprouver une ${isSuggestion ? 'blague' : 'correction'}.`
+          `Seuls un <@${godfatherRoleId}> peut désapprouver une ${isSuggestion ? 'blague' : 'correction'}.`
         )
       );
     }

--- a/src/bot/commands/disapprove.ts
+++ b/src/bot/commands/disapprove.ts
@@ -59,7 +59,7 @@ export default class DisapproveCommand extends Command {
     if (!isParrain(interaction.member)) {
       return interaction.reply(
         interactionProblem(
-          `Seuls un <@${godfatherRoleId}> peut désapprouver une ${isSuggestion ? 'blague' : 'correction'}.`
+          `Seul un <@${godfatherRoleId}> peut désapprouver une ${isSuggestion ? 'blague' : 'correction'}.`
         )
       );
     }

--- a/src/bot/commands/disapprove.ts
+++ b/src/bot/commands/disapprove.ts
@@ -17,7 +17,14 @@ import {
 } from '../constants';
 import Command from '../lib/command';
 import { renderGodfatherLine } from '../modules/godfathers';
-import { interactionProblem, interactionInfo, interactionValidate, isEmbedable, messageLink } from '../utils';
+import {
+  interactionProblem,
+  interactionInfo,
+  interactionValidate,
+  isEmbedable,
+  messageLink,
+  isParrain
+} from '../utils';
 
 export default class DisapproveCommand extends Command {
   constructor() {
@@ -44,6 +51,14 @@ export default class DisapproveCommand extends Command {
           `Vous ne pouvez pas désapprouver une ${isSuggestion ? 'blague' : 'correction'} qui n'est pas gérée par ${
             interaction.client.user
           }.`
+        )
+      );
+    }
+
+    if (!isParrain(interaction.member)) {
+      return interaction.reply(
+        interactionProblem(
+          `Vous n'êtes pas parrain, vous ne pouvez pas désapprouver une ${isSuggestion ? 'blague' : 'correction'}.`
         )
       );
     }

--- a/src/bot/utils.ts
+++ b/src/bot/utils.ts
@@ -1,4 +1,4 @@
-import { ContextMenuCommandInteraction, GuildMember, InteractionReplyOptions, TextChannel } from 'discord.js';
+import { GuildMember, InteractionReplyOptions, TextChannel } from 'discord.js';
 import { diffWords } from 'diff';
 import { APIEmbed } from 'discord-api-types/v10';
 import { godfatherRoleId } from './constants';

--- a/src/bot/utils.ts
+++ b/src/bot/utils.ts
@@ -84,6 +84,5 @@ export function messageLink(guildId: string, channelId: string, messageId: strin
 }
 
 export function isParrain(member: GuildMember) {
-  if (godfatherRoleId != '877511831525154837') return false;
   return member.roles.cache.has(godfatherRoleId);
 }

--- a/src/bot/utils.ts
+++ b/src/bot/utils.ts
@@ -1,6 +1,7 @@
-import { InteractionReplyOptions, TextChannel } from 'discord.js';
+import { ContextMenuCommandInteraction, GuildMember, InteractionReplyOptions, TextChannel } from 'discord.js';
 import { diffWords } from 'diff';
 import { APIEmbed } from 'discord-api-types/v10';
+import { godfatherRoleId } from './constants';
 
 export function interactionProblem(message: string, ephemeral = true): InteractionReplyOptions {
   return {
@@ -80,4 +81,9 @@ export function isEmbedable(channel: TextChannel) {
 
 export function messageLink(guildId: string, channelId: string, messageId: string) {
   return `https://discord.com/channels/${guildId}/${channelId}/${messageId}`;
+}
+
+export function isParrain(member: GuildMember) {
+  if (godfatherRoleId != '877511831525154837') return false;
+  return member.roles.cache.has(godfatherRoleId);
 }


### PR DESCRIPTION
Closes: #341 
Vérifier si le membre possède le rôle parrain avant de lancer la commande .
Pratique si les slashs permissions n'ont pas été configurer dans le serveur.