### PR TITLE
fix: 🐛 Fix joke by id endpoint

### DIFF
--- a/src/api/routes/jokes.ts
+++ b/src/api/routes/jokes.ts
@@ -68,7 +68,7 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     method: 'GET',
     onRequest: fastify.apiAuth,
     handler: async (req: JokeIdRequest, res) => {
-      const joke = jokeById(req.params.id);
+      const joke = jokeById(Number(req.params.id));
       if (!joke) {
         return res.status(404).send(JokeNotFound);
       }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -18,7 +18,7 @@ export type OptionalDisallowRequest = FastifyRequest<{
 }>;
 
 export type JokeIdRequest = FastifyRequest<{
-  Params: { id: number };
+  Params: { id: string };
 }>;
 
 export type JokeTypeRequest = FastifyRequest<{


### PR DESCRIPTION
Le soucis venait du fait que le `req.params.id` était typé comme `number` mais était un string au runtime, et comme on fait un check d'égalité strict sur les ids `===`, ducoup rien était renvoyé. J'ai juste update le typage et casté la valeur en nombre avant de l'utiliser

Closes #486 